### PR TITLE
Update Python Version Reqs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = ""
 authors = ["Your Name <you@example.com>"]
 
 [tool.poetry.dependencies]
-python = ">=3.8.0,<3.9"
+python = ">=3.12.1,<3.14"
 numpy = "^1.24.4"
 discord = "^2.3.2"
 Flask = "^3.0.3"


### PR DESCRIPTION
Minimum is Python 3.12.1, 3.13 is preferred, and 3.14 is not allowed.

Github is dropping 3.8, IDK why that was the used version. (My guess is remnant from using Replit)